### PR TITLE
[HK-02-01] PlayerManager의 isInputLock 방식 재구성

### DIFF
--- a/Assets/Scripts/Main/Player Action/Movement/HamsterMovementController.cs
+++ b/Assets/Scripts/Main/Player Action/Movement/HamsterMovementController.cs
@@ -76,7 +76,7 @@ public class HamsterMovementController : MonoBehaviour, IMovement
     {
         // 입력이 없거나 접착벽에 붙었다면 회전하지 않음
         if (PlayerManager.Instance.moveDir == Vector3.zero || PlayerManager.Instance.isOnStickyWall
-            || PlayerManager.Instance.isInputLock)
+            || PlayerManager.Instance.IsInputLock())
             return;
 
         Vector3 moveDir = PlayerManager.Instance.moveDir;

--- a/Assets/Scripts/Main/Player Action/Movement/PlayerMovementController.cs
+++ b/Assets/Scripts/Main/Player Action/Movement/PlayerMovementController.cs
@@ -193,13 +193,13 @@ public class PlayerMovementController : MonoBehaviour
     private void UpdateMovement()
     {
         // 입력이 잠기지 않았다면 이동 처리
-        if (!playerMgr.isInputLock)
+        if (!playerMgr.IsInputLock())
             playerMgr.isMoving = curMovement.Move();
 
         // 볼 상태가 아닐 때만 걷기 애니메이션 업데이트
         if (!playerMgr.isBall)
         {
-            bool setWalking = playerMgr.isInputLock ? false : playerMgr.isMoving;
+            bool setWalking = playerMgr.IsInputLock() ? false : playerMgr.isMoving;
             animator.SetBool("IsWalking", setWalking);
         }
     }
@@ -300,7 +300,7 @@ public class PlayerMovementController : MonoBehaviour
     private void HandleJumpInput()
     {
         jumped = false;
-        bool isInputLock = PlayerManager.Instance.isInputLock;
+        bool isInputLock = PlayerManager.Instance.IsInputLock();
 
         if (!playerMgr.isBall && playerMgr.onWire)
             return;
@@ -371,8 +371,7 @@ public class PlayerMovementController : MonoBehaviour
         rb.AddForce(normal * power + Vector3.up * 2, ForceMode.VelocityChange);
 
         // 일시적으로 입력 잠금
-        playerMgr.isInputLock = true;
-        playerMgr.SetInputLockAfterSeconds(false, 0.3f);
+        playerMgr.SetInputLockDuringSeconds(0.3f);
 
         // 점프 방향으로 회전 코루틴 시작
         StartCoroutine(SlideWallJumpRotate());
@@ -420,7 +419,7 @@ public class PlayerMovementController : MonoBehaviour
     {
         // 공중에서 스페이스바를 누르면 활공 토글
         if (!playerMgr.isGround && Input.GetKeyDown(KeyCode.Space) && !playerMgr.onWire
-            && !playerMgr.isInputLock)
+            && !playerMgr.IsInputLock())
         {
             // jumped : 이번 Update 프레임 때 점프를 했는지
             if (!jumped && playerMgr.skill.HasGliding())

--- a/Assets/Scripts/Main/Player Action/PlayerManager.cs
+++ b/Assets/Scripts/Main/Player Action/PlayerManager.cs
@@ -175,15 +175,6 @@ public class PlayerManager : RuntimeSingleton<PlayerManager>
     public Vector3 slideWallNormal;
 
     /// <summary>
-    /// 플레이어 입력이 현재 잠겨있는지 여부를 나타냅니다.
-    /// </summary>
-    /// <remarks>
-    /// 컷신, 대화, 특수 애니메이션 등 특정 상황에서 
-    /// 플레이어 입력을 일시적으로 비활성화할 때 사용됩니다.
-    /// </remarks>
-    public bool isInputLock;
-
-    /// <summary>
     /// 플레이어의 스킬 컨트롤러 참조입니다.
     /// </summary>
     /// <remarks>
@@ -207,13 +198,14 @@ public class PlayerManager : RuntimeSingleton<PlayerManager>
 
 
     #region Private Variables
+    private int inputLockNumber;
     private Rigidbody rb;
     private GameObject hamsterLightningShockParticle;
     private GameObject ballLightningShockParticle;
 
 
 
-    private Action modeConvert; // 
+    private Action modeConvert;
     private Vector3 accumulatedMovement;
     private const float LIGHTNING_SHOCK_COOLTIME = 3f;
     private bool canLightningShock;
@@ -235,6 +227,7 @@ public class PlayerManager : RuntimeSingleton<PlayerManager>
         hamsterLightningShockParticle?.SetActive(false);
         ballLightningShockParticle?.SetActive(false);
         canLightningShock = true;
+        inputLockNumber = 0;
 
         // 씬 리셋 시 구독자 전부 제거
         modeConvert = null;
@@ -242,7 +235,7 @@ public class PlayerManager : RuntimeSingleton<PlayerManager>
 
     private void Update()
     {
-        if (isInputLock) moveDir = Vector3.zero;
+        if (IsInputLock()) moveDir = Vector3.zero;
         else moveDir = GetInputMoveDir();
     }
 
@@ -338,25 +331,41 @@ public class PlayerManager : RuntimeSingleton<PlayerManager>
 
     #region Set Input Lock
     /// <summary>
-    /// 지정된 시간 후에 입력 잠금 상태를 설정합니다.
+    /// 지정된 시간 동안 입력을 잠금합니다.
     /// </summary>
-    /// <param name="isLock">잠금 상태 (true: 잠금, false: 해제)</param>
-    /// <param name="time">지연 시간 (초)</param>
+    /// <param name="time">입력을 잠금하는 시간(초)</param>
+    public void SetInputLockDuringSeconds(float lockedTime)
+    {
+        inputLockNumber++;
+        Invoke(nameof(DownInputLockNumber), lockedTime);
+    }
+
+    /// <summary>
+    /// 단순히 입력을 잠금하거나, 입력 잠금을 해제합니다.
+    /// </summary>
+    /// <param name="active">입력 잠금을 한다면 true</param>
     /// <remarks>
-    /// 특정 이벤트 후 일정 시간이 지난 뒤 입력 상태를 변경할 때 사용됩니다.
+    /// 입력이 잠금되는 시간을 직접 지정하기 어려울 때 사용합니다.
+    /// 반드시 SetInputLockPermanent(true/false) 쌍이 함께 있어야 합니다.
     /// </remarks>
-    public void SetInputLockAfterSeconds(bool isLock, float time)
+    public void SetInputLockPermanent(bool active)
     {
-        if (isLock) Invoke(nameof(SetInputLockTrue), time);
-        else Invoke(nameof(SetInputLockFalse), time);
+        if (active) inputLockNumber = Mathf.Max(1, inputLockNumber + 1);
+        else inputLockNumber--;
     }
-    private void SetInputLockTrue()
+    
+    /// <summary>
+    /// 입력이 잠금된 상태인지 여부를 반환합니다.
+    /// </summary>
+    /// <returns>입력이 잠금된 상태라면 True를 반환합니다.</returns>
+    public bool IsInputLock()
     {
-        isInputLock = true;
+        return inputLockNumber > 0;
     }
-    private void SetInputLockFalse()
+
+    private void DownInputLockNumber()
     {
-        isInputLock = false;
+        inputLockNumber--;
     }
     #endregion
 
@@ -369,8 +378,8 @@ public class PlayerManager : RuntimeSingleton<PlayerManager>
     /// 현재 상태의 반대 모드로 플레이어를 변환합니다.
     /// </summary>
     public void ModeConvert()
-    { 
-        modeConvert?.Invoke(); 
+    {
+        modeConvert?.Invoke();
     }
 
     /// <summary>
@@ -411,7 +420,6 @@ public class PlayerManager : RuntimeSingleton<PlayerManager>
         if (!canLightningShock)
             return;
 
-        isInputLock = true;
         canLightningShock = false;
         playerWire.EndShoot();
         isGliding = false;
@@ -421,12 +429,12 @@ public class PlayerManager : RuntimeSingleton<PlayerManager>
 
         GameManager.PlaySfx(SfxType.LightningShock);
 
+        SetInputLockDuringSeconds(LIGHTNING_SHOCK_COOLTIME);
         Invoke(nameof(LightningShockEndAfterFewSeconds), LIGHTNING_SHOCK_COOLTIME);
     }
     // inputLock 풀림, 전기효과 풀림
     private void LightningShockEndAfterFewSeconds()
     {
-        isInputLock = false;
         if (isBall) ballLightningShockParticle.SetActive(false);
         else hamsterLightningShockParticle.SetActive(false);
 

--- a/Assets/Scripts/Main/Player Action/Wire/HamsterWireController.cs
+++ b/Assets/Scripts/Main/Player Action/Wire/HamsterWireController.cs
@@ -98,7 +98,7 @@ public class HamsterWireController : MonoBehaviour, IWire
     {
         if (sj != null) 
             Destroy(sj);
-        PlayerManager.Instance.isInputLock = false;
+        SetIsInputLockFalse();
     }
 
     public void ShortenWire(bool isFast)
@@ -118,12 +118,12 @@ public class HamsterWireController : MonoBehaviour, IWire
         
         SetSpringWireLengthLimits(Vector3.Distance(transform.position, hitPoint.position));
 
-        PlayerManager.Instance.isInputLock = true;
+        PlayerManager.Instance.SetInputLockPermanent(true);
     }
 
     public void ShortenWireEnd(bool isFast)
     {
-        PlayerManager.Instance.isInputLock = false;
+        PlayerManager.Instance.SetInputLockPermanent(false);
         Invoke(nameof(SetIsInputLockFalse), 0.05f);
         Invoke(nameof(SetIsInputLockFalse), 0.1f);
         Debug.Log("ShortenWireEnd");
@@ -143,12 +143,12 @@ public class HamsterWireController : MonoBehaviour, IWire
         
         SetSpringWireLengthLimits(Vector3.Distance(transform.position, hitPoint.position));
 
-        PlayerManager.Instance.isInputLock = true;
+        PlayerManager.Instance.SetInputLockPermanent(true);
     }
 
     public void ExtendWireEnd()
     {
-        PlayerManager.Instance.isInputLock = false;
+        PlayerManager.Instance.SetInputLockPermanent(false);
         Invoke(nameof(SetIsInputLockFalse), 0.05f);
         Invoke(nameof(SetIsInputLockFalse), 0.1f);
         Debug.Log("ExtendWireEnd");
@@ -206,7 +206,8 @@ public class HamsterWireController : MonoBehaviour, IWire
     /// </summary>
     private void SetIsInputLockFalse()
     {
-        PlayerManager.Instance.isInputLock = false;
+        while (PlayerManager.Instance.IsInputLock())
+            PlayerManager.Instance.SetInputLockPermanent(false);
     }
     #endregion
 

--- a/Assets/Scripts/Main/Player Action/Wire/PlayerWireController.cs
+++ b/Assets/Scripts/Main/Player Action/Wire/PlayerWireController.cs
@@ -148,7 +148,7 @@ public class PlayerWireController : MonoBehaviour
         if (!EventSystem.current.IsPointerOverGameObject())
         {
             // 와이어 발사
-            if (Input.GetMouseButtonDown(0) && !PlayerManager.Instance.isInputLock)
+            if (Input.GetMouseButtonDown(0) && !PlayerManager.Instance.IsInputLock())
             {
                 WireShoot();
             }
@@ -161,7 +161,7 @@ public class PlayerWireController : MonoBehaviour
             // 빠르게 와이어 감기
             if (PlayerManager.Instance.skill.HasRetractor())
             {
-                if (Input.GetMouseButtonDown(1) && !PlayerManager.Instance.isInputLock)
+                if (Input.GetMouseButtonDown(1) && !PlayerManager.Instance.IsInputLock())
                 {
                     shortenStartTime = Time.time;
                     isShortenWireFast = true;
@@ -182,7 +182,7 @@ public class PlayerWireController : MonoBehaviour
         if (PlayerManager.Instance.skill.HasRetractor())
         {
             // 와이어 감기
-            if (Input.GetKeyDown(KeyCode.Q) && !PlayerManager.Instance.isInputLock)
+            if (Input.GetKeyDown(KeyCode.Q) && !PlayerManager.Instance.IsInputLock())
             {
                 shortenStartTime = Time.time;
                 isShortenWireSlow = true;
@@ -193,7 +193,7 @@ public class PlayerWireController : MonoBehaviour
             }
 
             //와이어 풀기
-            if (Input.GetKeyDown(KeyCode.E) && !PlayerManager.Instance.isInputLock)
+            if (Input.GetKeyDown(KeyCode.E) && !PlayerManager.Instance.IsInputLock())
             {
                 extendStartTime = Time.time;
                 isExtendWire = true;

--- a/Assets/Scripts/Main/Track/GymBallController.cs
+++ b/Assets/Scripts/Main/Track/GymBallController.cs
@@ -47,8 +47,7 @@ public class GymBallController : MonoBehaviour
             // 플레이어라면 입력 제한 걸기
             if (collision.gameObject.CompareTag("Player"))
             {
-                PlayerManager.Instance.isInputLock = true;
-                PlayerManager.Instance.SetInputLockAfterSeconds(false, 0.4f);
+                PlayerManager.Instance.SetInputLockDuringSeconds(0.4f);
             }
         }
     }

--- a/Assets/Scripts/Main/Track/SlideWallController.cs
+++ b/Assets/Scripts/Main/Track/SlideWallController.cs
@@ -51,7 +51,7 @@ public class SlideWallController : MonoBehaviour
             return;
 
         // 슬라이드벽에서 점프를 해서 입력에 락 걸림
-        if (PlayerManager.Instance.isInputLock)
+        if (PlayerManager.Instance.IsInputLock())
             return;
 
         connectedBody.velocity = new Vector3(connectedBody.velocity.x, 0, connectedBody.velocity.z);

--- a/Assets/Scripts/Main/Track/TrampolineController.cs
+++ b/Assets/Scripts/Main/Track/TrampolineController.cs
@@ -28,7 +28,7 @@ public class TrampolineController : MonoBehaviour
 
     private void Update()
     {
-        if (Input.GetKeyDown(KeyCode.Space) && !PlayerManager.Instance.isInputLock) 
+        if (Input.GetKeyDown(KeyCode.Space) && !PlayerManager.Instance.IsInputLock()) 
         {
             isJump = true;
             jumpStartTime = Time.time;


### PR DESCRIPTION
## 개요
- 기존에는 직접 isInputLock에 접근하고 isInputLock 값을 직접 true/false로 지정했습니다.
- 두 함수에서 동시에 inputLock을 true로 했다가 false로 하는 과정에서 오류가 생길 수 있겠다고 생각했습니다.
- 내부에서는 inputLock이 요청된 개수를 파악하고, 함수를 통해 지정된 시간이 지나면 inputLock 개수를 내립니다. inputLock 개수가 1 이상일 때 입력이 잠금됐다고 판단합니다.

----

- 관련 함수 (PlayerManager > #region Set Input Lock)
1. public void SetInputLockDuringSeconds(float lockedTime)
    - lockedTime 시간 동안 입력을 잠급니다.
2. public void SetInputLockPermanent(bool active)
    - 단순히 입력을 잠그거나 잠금을 해제합니다.
3. public bool IsInputLock()
    - 입력이 잠금되었는지 여부를 반환합니다.

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## Screenshots
시각적인 변경 사항이 있을 경우, 스크린샷이나 GIF를 첨부해 주세요.

## Notes for Reviewer:
리뷰 시 특별히 확인해 주셨으면 하는 부분이 있다면 작성해 주세요.

## Additional Coments:
슬라이드벽, 전기레이저, 햄스터 와이어의 리트랙터 도중 상황에서 입력 잠금 테스트를 마쳤습니다.
