### PR TITLE
[U-19] 레벨업 단축 기능 추가

### DIFF
--- a/Assets/Scripts/Main/Item/ItemManager.cs
+++ b/Assets/Scripts/Main/Item/ItemManager.cs
@@ -320,6 +320,11 @@ public class ItemManager : PersistentSingleton<ItemManager>
             return false;
         }
 
+        if (!userItem.CanLevelUp())
+        {
+            HLogger.Player.Warning($"아이템 레벨 업 불가: {item.name} (ID: {item.id})", this);
+            return false;
+        }
 
         if (!SpendCoin(userItem.GetCurrentPrice()))
         {

--- a/Assets/Scripts/Main/UI/Store/UI_StoreStandItem.cs
+++ b/Assets/Scripts/Main/UI/Store/UI_StoreStandItem.cs
@@ -50,28 +50,60 @@ public class UI_StoreStandItem : MonoBehaviour
 
     public void OnIncrementClicked()
     {
-        bool success = ItemManager.Instance.TryIncrementItem(userItem.item);
-        if (success)
+        bool isShift = Input.GetKey(KeyCode.LeftShift) || Input.GetKey(KeyCode.RightShift);
+        int attempts = 0;
+
+        if (isShift)
         {
-            Debug.Log($"구매 성공: {userItem.item.name}");
-            // TODO: Refresh UI 상태
+            while (ItemManager.Instance.TryIncrementItem(userItem.item)) {
+                if (attempts++ > 13)
+                {
+                    break;
+                }
+            }
+            Debug.Log($"Shift+클릭: {userItem.item.name}을 가능한 만큼 레벨 업 완료");
         }
         else
         {
-            Debug.Log($"구매 실패: {userItem.item.name} (코인 부족 또는 조건 불충족)");
+            bool success = ItemManager.Instance.TryIncrementItem(userItem.item);
+            if (success)
+            {
+                Debug.Log($"구매 성공: {userItem.item.name}");
+            }
+            else
+            {
+                Debug.Log($"구매 실패: {userItem.item.name} (코인 부족 또는 조건 불충족)");
+            }
         }
     }
 
     public void OnDecrementClicked()
     {
-        bool success = ItemManager.Instance.TryDecrementItem(userItem.item);
-        if (success)
+        bool isShift = Input.GetKey(KeyCode.LeftShift) || Input.GetKey(KeyCode.RightShift);
+        int attempts = 0;
+
+        if (isShift)
         {
-            Debug.Log($"레벨 다운 성공: {userItem.item.name}");
+            while (ItemManager.Instance.TryDecrementItem(userItem.item))
+            {
+                if (attempts++ > 13)
+                {
+                    break;
+                }
+            }
+            Debug.Log($"Shift+클릭: {userItem.item.name}을 가능한 만큼 레벨 다운 완료");
         }
         else
         {
-            Debug.Log($"레벨 다운 실패: {userItem.item.name} (조건 불충족)");
+            bool success = ItemManager.Instance.TryDecrementItem(userItem.item);
+            if (success)
+            {
+                Debug.Log($"레벨 다운 성공: {userItem.item.name}");
+            }
+            else
+            {
+                Debug.Log($"레벨 다운 실패: {userItem.item.name} (조건 불충족)");
+            }
         }
     }
 }


### PR DESCRIPTION
유저 상점에서 코인 한도 이내에서 세팅을 계속 조절할 수 있는 만큼 코인이나 맥스 레벨 이내에서 허용하는 한 한 번에 레벨을 조정할 수 있도록 기능을 추가하였습니다.

Shift를 누르면서 버튼을 클릭하면 빠른 레벨 업 / 레벨 다운이 가능합니다.

## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

<!---- Resolves: #(Isuue Number) -->

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## Screenshots
시각적인 변경 사항이 있을 경우, 스크린샷이나 GIF를 첨부해 주세요.

## Notes for Reviewer:
리뷰 시 특별히 확인해 주셨으면 하는 부분이 있다면 작성해 주세요.

## Additional Coments:
리뷰에 도움이 될 수 있는 기타 참고 사항이나 코멘트를 자유롭게 작성해 주세요.

